### PR TITLE
Use correct name for virus

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
     <meta name="author" content="OSWINDS">
     <meta name="keyword" content="covid19, deaths, cases, greece,covid-19,pandemia">
 
-    <title> Ο Co-vid 19 σήμερα</title>
+    <title> Ο COVID-19 σήμερα</title>
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <!--external css-->
@@ -133,7 +133,7 @@
                             </button>
                         </div>
                         <div class="col-6">
-                            <a href="/" class="logo"><img src="static/img/icon.png" alt="Co-vid 19" id="icon"> Co-vid 19 Ενημερωση</a>
+                            <a href="/" class="logo"><img src="static/img/icon.png" alt="COVID-19" id="icon"> COVID-19 Ενημερωση</a>
                         </div>
                         <div class="col-4">
                             <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -164,11 +164,11 @@
             <div class="row below-header">
                 <div class="col">
                     <div class="row">
-                        <h2>Ο Co-vid 19 ΣΗΜΕΡΑ </h2>
+                        <h2>Ο COVID-19 ΣΗΜΕΡΑ </h2>
                     </div>
                     <div class="row">
                         <p class="intro intro-cases">
-                            Ενημερωτική ιστοσελίδα για τη δράση του Co-vid 19 παγκοσμίως και σύγκριση με τα
+                            Ενημερωτική ιστοσελίδα για τη δράση του COVID-19 παγκοσμίως και σύγκριση με τα
                             ελληνικά δεδομένα. Τα δεδομένα αφορούν το διάστημα: <br>
                             <span id="time-frame"></span>
                         </p>


### PR DESCRIPTION
The proper name seems to be COVID-19, not Co-vid 19.